### PR TITLE
File git_pull.sh

### DIFF
--- a/python_pull/git_pull.sh
+++ b/python_pull/git_pull.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd /root/repos/$1 && git fetch --all && git checkout --force "origin/master"


### PR DESCRIPTION
Place this file in /root/repos/python_pull/
If you want to keep it somewhere else, this path can be changed in git_hook.py

Make it executable - chmod +x git_pull.sh

Clone your target repo at /root/repos so that /root/repos/target_repo is the folder of your cloned repository
If you want to change this path, you can do it in this file on Line 3 - cd <path>$1 - here $1 represents 'target_repo'

In your webhook the URL will be <IP-of-Client>/payload/target_repo - check the @route in git_hook.py